### PR TITLE
Interoperates on IBM DFDL and Daffodil.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 CSV
 ====
 
-DFDL Schemas for CSV
+DFDL Schemas for CSV and CSV-like data formats.
 
-It works with Daffodil, but not tested with IBM DFDL.
+CSV stands for "Comma Separated Values". It is less a data format than a theme
+for many kinds of related data formats. This schema project includes more than one 
+variation. 
 
-Notes:
+The basic csv.dfdl.xsd schema is portable DFDL - it runs on both IBM DFDL, and 
+on the Apache Daffodil (Incubating - as of 2019-05-29), DFDL implementation.
 
-Included a copy of the daffodil built-in-formats for completeness.  Normally if using daffodil you
-would not need to physically include the file as it comes in the JAR with daffodil.
+Other variations include csvEnforceHeaders.dfdl.xsd which uses 
+dfdl:occursCountKind 'expression' and DFDL's fn:count(....) function to enforce
+the data rows having the same number of items as there are header titles.
+ 
+
+
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,27 +1,36 @@
-organization := "com.tresys"
-
-name := "dfdl-csv"
-
-version := "0.0.1"
-
-crossPaths := false
-
-scalaVersion := "2.11.12"
-
-testOptions in ThisBuild += Tests.Argument(TestFrameworks.JUnit, "-v")
-
-libraryDependencies in ThisBuild := Seq(
-  "junit" % "junit" % "4.11" % "test",
-  "com.novocode" % "junit-interface" % "0.11" % "test",
-  "org.apache.daffodil" %% "daffodil-tdml-processor" % "2.3.0" % "test"
-)
-
-scmInfo := Some(
-  ScmInfo(
-    browseUrl = url("https://github.com/DFDLSchemas/CSV"),
-    connection = "scm:git:https://github.com/DFDLSchemas/CSV.git")
-  )
-
-homepage in ThisBuild := Some(url("https://github.com/DFDLSchemas/CSV"))
-
+lazy val root = (project in file(".")).
+  settings(
+    inThisBuild(List(
+      organization := "com.tresys",
+      version      := "0.1.0-SNAPSHOT",
+      scalaVersion := "2.12.6",
+      crossPaths := false,
+      testOptions += Tests.Argument(TestFrameworks.JUnit, "-v"),
+      scmInfo := Some(
+        ScmInfo(
+        browseUrl = url("https://github.com/DFDLSchemas/CSV"),
+        connection = "scm:git:https://github.com/DFDLSchemas/CSV.git")
+      ),
+      homepage in ThisBuild := Some(url("https://github.com/DFDLSchemas/CSV"))
+    )),
+    name := "dfdl-csv",
+    libraryDependencies := Seq(
+      // 
+      // Note: for Daffodil 2.2.0, this module is named daffodil-tdml.
+      // For Daffodil 2.3.0+ (and latest.integration snapshots thereof) it is named
+      // daffodil-tdml-processor.
+      //
+      "org.apache.daffodil" %% "daffodil-tdml-processor" % "latest.integration" % "test",
+      "junit" % "junit" % "4.12" % "test",
+      "com.novocode" % "junit-interface" % "0.11" % "test"
+    ))  
+  //
+  // Uncomment this line below to run against IBM DFDL.
+  // You need to have IBM DFDL installed and the IBM DFDL Cross Tester
+  //
+  // Note: This requires a 2.3.0 release of daffodil. 
+  // (See version of daffodil-tdml-processor above)
+  // or a development snapshot (e.g., version "latest.integration")
+  // 
+  //.settings(IBMDFDLCrossTesterPlugin.settings)
 

--- a/src/main/resources/com/tresys/csv/xsd/csvHeaderEnforced.dfdl.xsd
+++ b/src/main/resources/com/tresys/csv/xsd/csvHeaderEnforced.dfdl.xsd
@@ -45,7 +45,7 @@ SOFTWARE.
         terminator="" textTrimKind="none" initiatedContent="no" ignoreCase="no"
         separatorPosition="infix" occursCountKind="implicit"
         emptyValueDelimiterPolicy="both" representation="text" textNumberRep="standard"
-        lengthKind="delimited" encoding="ASCII" encodingErrorPolicy="error" />
+        lengthKind="delimited" encoding="ASCII" />
     </xs:appinfo>
   </xs:annotation>
 
@@ -63,7 +63,12 @@ SOFTWARE.
         <xs:element name="record" maxOccurs="unbounded">
           <xs:complexType>
             <xs:sequence dfdl:separator=",">
-              <xs:element name="item" type="xs:string" maxOccurs="unbounded"/>
+            <!-- This version of item enforces the number of items matching
+                 The number of headers. However it is not portable across
+                 Daffodil and IBM DFDL, so is commented out. --> 
+              <xs:element name="item" type="xs:string" maxOccurs="unbounded"
+                dfdl:occursCount="{ fn:count(../../header/title) }"
+                dfdl:occursCountKind="expression" />
             </xs:sequence>
           </xs:complexType>
         </xs:element>

--- a/src/test/resources/com/tresys/csv/csv.tdml
+++ b/src/test/resources/com/tresys/csv/csv.tdml
@@ -1,51 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?Copyright <![CDATA[
-Copyright (c) 2012-2015 Tresys Technology, LLC. All rights reserved.
 
-Developed by: Tresys Technology, LLC
-              http://www.tresys.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal with
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
- 1. Redistributions of source code must retain the above copyright notice,
-    this list of conditions and the following disclaimers.
-
- 2. Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimers in the
-    documentation and/or other materials provided with the distribution.
-
- 3. Neither the names of Tresys Technology, nor the names of its contributors
-    may be used to endorse or promote products derived from this Software
-    without specific prior written permission.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
-SOFTWARE.
-]]> ?>
 <testSuite suiteName="Namespaces"
   xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" 
   xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
   defaultRoundTrip="onePass">
 
-  <?Comment
+  <!-- 
     Test name: csv_test
        Schema: csv.dfdl.xsd
          Root: file
       Purpose: This test is to exercise the csv schema.
-  ?>
+  -->
   
-  <tdml:parserTestCase name="csv_test" root="file"
+  <tdml:parserTestCase name="csv_test_p" root="file"
     model="com/tresys/csv/xsd/csv.dfdl.xsd" description="csv test"
-    roundTrip="onePass">
+    roundTrip="none">
     <tdml:document>
       <tdml:documentPart type="file">data/simpleCSV.csv</tdml:documentPart>
     </tdml:document>
@@ -54,20 +23,44 @@ SOFTWARE.
     </tdml:infoset>
   </tdml:parserTestCase>
   
+  <tdml:unparserTestCase name="csv_test_u" root="file"
+    model="com/tresys/csv/xsd/csv.dfdl.xsd" description="csv test"
+    roundTrip="none">
+    <tdml:document>
+      <tdml:documentPart type="file">data/simpleCSV.csv</tdml:documentPart>
+    </tdml:document>
+    <tdml:infoset>
+      <tdml:dfdlInfoset type="file">infosets/simpleCSV.xml</tdml:dfdlInfoset>
+    </tdml:infoset>
+  </tdml:unparserTestCase>
+  
   <!--
     Test name: csv_test_2
        Schema: csv.dfdl.xsd
          Root: file
       Purpose: This test is to exercise the csv schema with an incorrect matching 
-               of header title number with element number
+               of header title number with element number.
   -->
   
   <tdml:parserTestCase name="csv_test_2" root="file"
-    model="com/tresys/csv/xsd/csv.dfdl.xsd" description="csv test">
+    model="com/tresys/csv/xsd/csvHeaderEnforced.dfdl.xsd" description="csv test"
+    implementations="daffodil">
     <tdml:document><![CDATA[last,first,middle,DOB
 baratheon,robert,brandon,1988-03-24,extra,extra
 johnson,john,henry,1986-01-23
 stark,arya,cat,1986-02-19
+]]></tdml:document>
+    <tdml:errors>
+      <tdml:error>Parse Error</tdml:error>
+      <tdml:error>Found out of scope delimiter</tdml:error>
+    </tdml:errors>
+  </tdml:parserTestCase>
+  
+  <tdml:parserTestCase name="csv_test_3" root="file"
+    model="com/tresys/csv/xsd/csvHeaderEnforced.dfdl.xsd" description="csv test"
+    implementations="daffodil">
+    <tdml:document><![CDATA[last,first,middle,DOB
+johnson,john,henry
 ]]></tdml:document>
     <tdml:errors>
       <tdml:error>Parse Error</tdml:error>

--- a/src/test/resources/com/tresys/csv/infosets/simpleCSV.xml
+++ b/src/test/resources/com/tresys/csv/infosets/simpleCSV.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ex:file xmlns:ex="http://example.com">
   <header>
     <title>last</title>

--- a/src/test/scala/com/tresys/csv/TestCSV.scala
+++ b/src/test/scala/com/tresys/csv/TestCSV.scala
@@ -46,7 +46,9 @@ object TestCSV {
 class TestCSV {
   import TestCSV._
 
-  @Test def test_csv_test() { runner.runOneTest("csv_test") }
+  @Test def test_csv_test_p() { runner.runOneTest("csv_test_p") }
+  @Test def test_csv_test_u() { runner.runOneTest("csv_test_u") }
   @Test def test_csv_test_2() { runner.runOneTest("csv_test_2") }
+  @Test def test_csv_test_3() { runner.runOneTest("csv_test_3") }
 
 }


### PR DESCRIPTION
Has two variants: a regular CSV schema and one that uses fn:count(...)
and occursCountKind='expression' to enforce the number of items in each
row matching the number of header titles.

Updated build.sbt to new syntax.

Remove use of XML processing instructions for comments.
Interferes with XML tooling.

Updated README.md to reflect portability.